### PR TITLE
Update MapLibre library names in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# MapLibre GL Basemaps Control
+# MapLibre GL JS Basemaps Control
 
 > The core interactions and styling of this control is based on [Leaflet.Basemaps](https://github.com/consbio/Leaflet.Basemaps)
 
-A Maplibre GL Control for switching between basemaps. The control only supports raster sources.
+A MapLibre GL JS Control for switching between basemaps. The control only supports raster sources.
 
 [Demo](https://ka7eh.github.io/maplibre-gl-basemaps/example)
 
@@ -19,7 +19,7 @@ map.addControl(new BasemapsControl(options));
 
 To run the examples locally, install the dependencies and run `npm run examples`.
 
-Go to `localhost:8080` for Maplibre GL example and `localhost:8080/example.mapbox.html` for Mapbox GL example.
+Go to `localhost:8080` for MapLibre GL JS example and `localhost:8080/example.mapbox.html` for Mapbox GL example.
 
 ## Options
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A MapLibre GL JS Control for switching between basemaps. The control only suppor
 
 [Demo](https://ka7eh.github.io/maplibre-gl-basemaps/example)
 
-> This should work with Mapbox GL too. See `example.mapboxgl.html`. You need to add a Mapbox access token to run this example.
+> This should work with Mapbox GL JS too. See `example.mapboxgl.html`. You need to add a Mapbox access token to run this example.
 
 ## Usage
 
@@ -19,7 +19,7 @@ map.addControl(new BasemapsControl(options));
 
 To run the examples locally, install the dependencies and run `npm run examples`.
 
-Go to `localhost:8080` for MapLibre GL JS example and `localhost:8080/example.mapbox.html` for Mapbox GL example.
+Go to `localhost:8080` for MapLibre GL JS example and `localhost:8080/example.mapbox.html` for Mapbox GL JS example.
 
 ## Options
 
@@ -36,6 +36,6 @@ Go to `localhost:8080` for MapLibre GL JS example and `localhost:8080/example.ma
 | Attribute         | Description                                                                                                                                         |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
 | id                | The string to use for both the basemap source and layer                                                                                             |
-| tiles             | An array of one or more tile source URLs, as in the TileJSON spec (https://maplibre.org/maplibre-gl-js-docs/style-spec/sources/#raster-tiles)       |
-| sourceExtraParams | Other parameters accepted by MapLibre GL raster source to pass to the basemap (https://maplibre.org/maplibre-gl-js-docs/style-spec/sources/#raster) |
-| layerExtraParams  | Other parameters accepted by MapLibre GL raster layer to pass to the basemap (https://maplibre.org/maplibre-gl-js-docs/style-spec/layers/#raster)   |
+| tiles             | An array of one or more tile source URLs, as in the TileJSON spec (https://maplibre.org/maplibre-style-spec/sources/#raster-tiles)       |
+| sourceExtraParams | Other parameters accepted by MapLibre raster source to pass to the basemap (https://maplibre.org/maplibre-style-spec/sources/#raster) |
+| layerExtraParams  | Other parameters accepted by MapLibre raster layer to pass to the basemap (https://maplibre.org/maplibre-style-spec/layers/#raster)   |

--- a/example.html
+++ b/example.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-  <title>MapLibre GL Basemaps Control</title>
+  <title>MapLibre GL JS Basemaps Control</title>
 
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
   <link href="https://unpkg.com/maplibre-gl@2.1.6/dist/maplibre-gl.css" rel="stylesheet" />


### PR DESCRIPTION
small adjustments to the readme to reflect the current naming conventions